### PR TITLE
Separação de campo telefone com 2 telefones

### DIFF
--- a/src/CnpjGratis.php
+++ b/src/CnpjGratis.php
@@ -173,6 +173,14 @@ class CnpjGratis {
                 }
             }
         }
+        
+        $posBarra = strpos($result['telefone'], '/');
+        
+        if ($posBarra > 0) {
+            $result['telefone2'] = substr($result['telefone'], $posBarra + 1, strlen($result['telefone']) - $posBarra);
+            $result['telefone'] = substr($result['telefone'], 0, $posBarra - 1);
+        }
+        
 
         return $result;
     }


### PR DESCRIPTION
Esta altera adiciona a chave 'telefone2' onde quando for encontrado barra '/' no campo telefone e altera a chave 'telefone' removendo referencia do segundo numero de telefone.